### PR TITLE
Use Wiktionary for word search

### DIFF
--- a/src/main/java/org/billthefarmer/gurgle/Gurgle.java
+++ b/src/main/java/org/billthefarmer/gurgle/Gurgle.java
@@ -98,6 +98,7 @@ public class Gurgle extends Activity
     public static final String KEYS = "keys";
     public static final String DATA = "data";
     public static final String WORD = "word";
+    public static final String LANG = "lang";
     public static final String SOLVED = "solved";
     public static final String LETTER = "letter";
     public static final String LETTERS = "letters";
@@ -1145,6 +1146,37 @@ public class Gurgle extends Activity
         return 0;
     }
 
+    private static String languageToString(int l)
+    {
+        switch (l)
+        {
+        default:
+        case ENGLISH:
+		return "en";
+
+        case ITALIAN:
+		return "it";
+
+        case SPANISH:
+		return "es";
+
+        case CATALAN:
+		return "ca";
+
+        case FRENCH:
+		return "fr";
+
+        case PORTUGUESE:
+		return "pt";
+
+        case GERMAN:
+		return "de";
+
+        case DUTCH:
+		return "nl";
+        }
+    }
+
     // setLanguage
     private void setLanguage(int l)
     {
@@ -1234,6 +1266,7 @@ public class Gurgle extends Activity
         // Start the web search
         Intent intent = new Intent(this, Search.class);
         intent.putExtra(WORD, guess.toString().toLowerCase(Locale.getDefault()));
+        intent.putExtra(LANG, languageToString(language));
         startActivity(intent);
     }
 

--- a/src/main/java/org/billthefarmer/gurgle/Search.java
+++ b/src/main/java/org/billthefarmer/gurgle/Search.java
@@ -40,7 +40,7 @@ import java.util.Locale;
 public class Search extends Activity
 {
     public static final String FORMAT =
-        "https://duckduckgo.com/?q=%s&ia=definition";
+        "https://%s.wiktionary.org/wiki/%s";
 
     private WebView webview;
 
@@ -130,8 +130,9 @@ public class Search extends Activity
             {
                 // Get the word from the intent and create url
                 Intent intent = getIntent();
+                String lang = intent.getStringExtra(Gurgle.LANG);
                 String word = intent.getStringExtra(Gurgle.WORD);
-                String url = String.format(Locale.getDefault(), FORMAT, word);
+                String url = String.format(Locale.getDefault(), FORMAT, lang, word);
 
                 // Do web search
                 webview.loadUrl(url);

--- a/src/main/java/org/billthefarmer/gurgle/Search.java
+++ b/src/main/java/org/billthefarmer/gurgle/Search.java
@@ -34,6 +34,9 @@ import android.webkit.WebSettings;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 
 // SearchActivity
@@ -132,6 +135,12 @@ public class Search extends Activity
                 Intent intent = getIntent();
                 String lang = intent.getStringExtra(Gurgle.LANG);
                 String word = intent.getStringExtra(Gurgle.WORD);
+		try
+		{
+			word = URLEncoder.encode(word, StandardCharsets.UTF_8.toString());
+		}
+		catch (UnsupportedEncodingException e) {}
+
                 String url = String.format(Locale.getDefault(), FORMAT, lang, word);
 
                 // Do web search


### PR DESCRIPTION
Wiktionary allows specifying the word's language which results in more
accurate results. DuckDuckGo only worked well for English.

Closes issue #53.